### PR TITLE
vsphere-csi: Update default repo for driver/syncer

### DIFF
--- a/mirantis/vsphere-csi-driver/Chart.yaml
+++ b/mirantis/vsphere-csi-driver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirantis/vsphere-csi-driver/README.md
+++ b/mirantis/vsphere-csi-driver/README.md
@@ -31,13 +31,13 @@ values under `vcenterConfig`.
 | images.csiResizer.tag                    | string | `"v1.10.1"`                                               | Tag for the CSI resizer                                                            |
 | images.csiSnapshotter.repo               | string | `"registry.k8s.io/sig-storage/csi-snapshotter"`           | Repo for the CSI snapshotter                                                       |
 | images.csiSnapshotter.tag                | string | `"v7.0.2"`                                                | Tag for the CSI snapshotter                                                        |
-| images.driver.repo                       | string | `"gcr.io/cloud-provider-vsphere/csi/release/driver"`      | Repo for the vcenter CSI provider driver                                           |
+| images.driver.repo                       | string | `"registry.k8s.io/csi-vsphere/driver"`                    | Repo for the vcenter CSI provider driver                                           |
 | images.driver.tag                        | string | `"v3.3.1"`                                                | Tag for the vcenter CSI provider driver                                            |
 | images.livenessProbe.repo                | string | `"registry.k8s.io/sig-storage/livenessprobe"`             | Repo for the livenessprobe                                                         |
 | images.livenessProbe.tag                 | string | `"v2.12.0"`                                               | Tag for the livenessprobe                                                          |
 | images.nodeDriverRegistrar.repo          | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | Repo for the CSI driver registrar                                                  |
 | images.nodeDriverRegistrar.tag           | string | `"v2.10.1"`                                               | Tag for the CSI driver registrar                                                   |
-| images.syncer.repo                       | string | `"gcr.io/cloud-provider-vsphere/csi/release/syncer"`      | Repo for the vcenter CSI provider syncer                                           |
+| images.syncer.repo                       | string | `"registry.k8s.io/csi-vsphere/syncer"`                   | Repo for the vcenter CSI provider syncer                                           |
 | images.syncer.tag                        | string | `"v3.3.1"`                                                | Tag for the vcenter CSI provider syncer                                            |
 | node.kubeletPath                         | string | `"/var/lib/kubelet"`                                      | Kubelet path on the node                                                           |
 | node.tolerations                         | map    |                                                           | Node provisioner tolerations                                                       |

--- a/mirantis/vsphere-csi-driver/values.yaml
+++ b/mirantis/vsphere-csi-driver/values.yaml
@@ -55,10 +55,10 @@ vcenterConfig:
 
 images:
   driver:
-    repo: gcr.io/cloud-provider-vsphere/csi/release/driver
+    repo: registry.k8s.io/csi-vsphere/driver
     tag: v3.3.1
   syncer:
-    repo: gcr.io/cloud-provider-vsphere/csi/release/syncer
+    repo: registry.k8s.io/csi-vsphere/syncer
     tag: v3.3.1
   nodeDriverRegistrar:
     repo: registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
The vsphere-csi-driver project no longer uses `gcr.io` to host their images and a driver installed with the default values of this chart will result in an `ImagePullBackOff`.  This bumps the chart version to `0.0.2` and updates the repo defaults to these: https://github.com/kubernetes-sigs/vsphere-csi-driver?tab=readme-ov-file#vsphere-csi-driver-releases

Relates to https://github.com/Mirantis/hmc/pull/360