### PR TITLE
Set volumeBindingMode to WaitForFirstConsumer in the default GCP storage class

### DIFF
--- a/mirantis/gcp-compute-persistent-disk-csi-driver/Chart.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirantis/gcp-compute-persistent-disk-csi-driver/templates/sc.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/templates/sc.yaml
@@ -9,4 +9,5 @@ metadata:
 provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-standard
+volumeBindingMode: WaitForFirstConsumer
 {{- end }}


### PR DESCRIPTION
This is needed to ensure the volume is only provisioned after the pod is scheduled, matching the node’s zone. By default, the Immediate binding mode is set, forcing the PV to be created in a zone before the pod is scheduled which may cause zones' mismatch.