### PR TITLE
 fix(gcp): bind cloud-provider SA for CCM; gate broken CSI taint-controller

### DIFF
--- a/mirantis/gcp-cloud-controller-manager/templates/clusterrolebindings.yaml
+++ b/mirantis/gcp-cloud-controller-manager/templates/clusterrolebindings.yaml
@@ -26,3 +26,7 @@ subjects:
   apiGroup: ""
   name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  apiGroup: ""
+  name: {{ .Values.legacyServiceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/mirantis/gcp-cloud-controller-manager/values.yaml
+++ b/mirantis/gcp-cloud-controller-manager/values.yaml
@@ -58,6 +58,7 @@ apiServerAuthRoleBindingName: cloud-controller-manager:apiserver-authentication-
 apiServerAuthRoleName: extension-apiserver-authentication-reader
 
 serviceAccountName: cloud-controller-manager
+legacyServiceAccountName: cloud-provider
 
 extraVolumes: []
 extraVolumeMounts: []

--- a/mirantis/gcp-compute-persistent-disk-csi-driver/templates/controller-deploy.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/templates/controller-deploy.yaml
@@ -18,7 +18,13 @@ spec:
       labels: {{- include "gcp-csi.selectorLabels" . | nindent 8 }}
         component: {{ template "csi-controller.name" . }}
     spec:
-      tolerations: {{ toYaml ( .Values.controller.tolerations | default .Values.controller.tolerations ) | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.controller.tolerations | nindent 8 }}
+        {{- if .Values.controller.tainter.enabled }}
+        - effect: NoSchedule
+          key: pd.csi.storage.gke.io/startup
+          operator: Exists
+        {{- end }}
       nodeSelector: {{ toYaml ( .Values.controller.nodeSelector | default .Values.controller.nodeSelector ) | nindent 8 }}
       hostNetwork: true
       serviceAccountName: {{ .Values.controller.serviceAccountName }}
@@ -167,6 +173,7 @@ spec:
               readOnly: true
               mountPath: /etc/kubernetes/{{ .Values.cloudCredentials.secretKey }}
               subPath: {{ .Values.cloudCredentials.secretKey }}
+        {{- if .Values.controller.tainter.enabled }}
         - name: taint-controller
           image: {{ .Values.controller.tainter.image.repository }}:{{ .Values.controller.tainter.image.tag }}
           {{- with .Values.controller.tainter.command }}
@@ -191,6 +198,7 @@ spec:
               readOnly: true
               mountPath: /etc/kubernetes/{{ .Values.cloudCredentials.secretKey }}
               subPath: {{ .Values.cloudCredentials.secretKey }}
+        {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/mirantis/gcp-compute-persistent-disk-csi-driver/templates/rbac/clusterrolebindings.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/templates/rbac/clusterrolebindings.yaml
@@ -82,6 +82,7 @@ roleRef:
   name: {{ .Values.controller.snapshotter.roleName }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if .Values.controller.tainter.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -95,3 +96,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.controller.tainter.roleName }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/mirantis/gcp-compute-persistent-disk-csi-driver/templates/rbac/clusterroles.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/templates/rbac/clusterroles.yaml
@@ -110,6 +110,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
+{{- if .Values.controller.tainter.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -123,3 +124,4 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch", "patch", "update"]
+{{- end }}

--- a/mirantis/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/mirantis/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -17,10 +17,7 @@ controller:
   nameOverride: ""
   podSecurityContext: {}
   podAnnotations: {}
-  tolerations:
-    - effect: NoSchedule
-      key: pd.csi.storage.gke.io/startup
-      operator: Exists
+  tolerations: []
 
   priorityClass:
     name: csi-gce-pd-controller
@@ -103,6 +100,10 @@ controller:
       - "--run-node-service=false"
 
   tainter:
+    # enabled is false because [run-taint-controller, taint-metrics-addr] was not added to the
+    # gce-pd-csi-driver binary in v1.17.x (upstream breakage). Set to true only
+    # when a fixed upstream image is available.
+    enabled: false
     image:
       repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
       tag: v1.17.4


### PR DESCRIPTION
  ## Summary

  Updates the Mirantis GCP CCM and PD CSI charts.
  
  ### What changed

  gcp-cloud-controller-manager
  - Extend the system:cloud-controller-manager ClusterRoleBinding with a second subject: the cloud-provider ServiceAccount (value: legacyServiceAccountName, default cloud-provider).
  - Why: k0s creates this SA for CCM sub-controllers when --use-service-account-credentials=true is set. GCP CCM v36.x may run the service/load-balancer path as cloud-provider; without this binding, services/status updates (finalizers, LB status) fail with RBAC errors even though the main DaemonSet uses cloud-controller-manager.

  gcp-compute-persistent-disk-csi-driver
  - Add controller.tainter.enabled (default false) and wrap in that flag:
    - the taint-controller sidecar
    - pd-csi-taint-controller-* RBAC
    - the pd.csi.storage.gke.io/startup toleration on the controller Deployment
  - Why: Upstream [added a taint/removal flow](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/commit/5e31735ba4a96959838e04717652da659cc9f3cd); the --run-taint-controller mode is broken for the shipped gce-pd-csi-driver image (unrecognized flags). Disabling by default keeps provisioning/node sidecars healthy until upstream fixes the binary or flags.